### PR TITLE
PersistentDateTimeAsBigInt

### DIFF
--- a/src/main/java/org/joda/time/contrib/hibernate/PersistentDateTimeAsBigInt.java
+++ b/src/main/java/org/joda/time/contrib/hibernate/PersistentDateTimeAsBigInt.java
@@ -1,0 +1,117 @@
+/*
+ *  Copyright 2001-2011 Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.time.contrib.hibernate;
+
+import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import org.hibernate.HibernateException;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.usertype.EnhancedUserType;
+import org.joda.time.DateTime;
+
+/**
+ * Persist {@link org.joda.time.DateTime} via hibernate as a BIGINT.
+ * 
+ * @author Martin Grove (marting@optrak.co.uk))
+ */
+public class PersistentDateTimeAsBigInt implements EnhancedUserType, Serializable {
+
+    public static final PersistentDateTimeAsBigInt INSTANCE = new PersistentDateTimeAsBigInt();
+
+    private static final int[] SQL_TYPES = new int[] { Types.BIGINT };
+
+    public int[] sqlTypes() {
+        return SQL_TYPES;
+    }
+
+    public Class returnedClass() {
+        return DateTime.class;
+    }
+
+    public boolean equals(Object x, Object y) throws HibernateException {
+        if (x == y) {
+            return true;
+        }
+        if (x == null || y == null) {
+            return false;
+        }
+        DateTime ix = (DateTime) x;
+        DateTime iy = (DateTime) y;
+        return ix.equals(iy);
+    }
+
+    public int hashCode(Object object) throws HibernateException {
+        return object.hashCode();
+    }
+
+    public Object nullSafeGet(ResultSet resultSet, String[] names, Object object) throws HibernateException, SQLException {
+        return nullSafeGet(resultSet, names[0]);
+    }
+
+    public Object nullSafeGet(ResultSet resultSet, String name) throws HibernateException, SQLException {
+        Object value = StandardBasicTypes.LONG.nullSafeGet(resultSet, name);
+        if (value == null) {
+            return null;
+        }
+        return new DateTime(value);
+    }
+
+    public void nullSafeSet(PreparedStatement preparedStatement, Object value, int index) throws HibernateException, SQLException {
+        if (value == null) {
+            StandardBasicTypes.LONG.nullSafeSet(preparedStatement, null, index);
+        } else {
+            StandardBasicTypes.LONG.nullSafeSet(preparedStatement, new Long(((DateTime) value).getMillis()), index);
+        }
+    }
+
+    public Object deepCopy(Object value) throws HibernateException {
+        return value;
+    }
+
+    public boolean isMutable() {
+        return false;
+    }
+
+    public Serializable disassemble(Object value) throws HibernateException {
+        return (Serializable) value;
+    }
+
+    public Object assemble(Serializable serializable, Object value) throws HibernateException {
+        return serializable;
+    }
+
+    public Object replace(Object original, Object target, Object owner) throws HibernateException {
+        return original;
+    }
+
+    // __________ EnhancedUserType ____________________
+
+    public String objectToSQLString(Object object) {
+        throw new UnsupportedOperationException();
+    }
+
+    public String toXMLString(Object object) {
+        return object.toString();
+    }
+
+    public Object fromXMLString(String string) {
+        return new DateTime(string);
+    }
+
+}

--- a/src/test/java/org/joda/time/contrib/hibernate/TestPersistentDateTimeAsBigInt.java
+++ b/src/test/java/org/joda/time/contrib/hibernate/TestPersistentDateTimeAsBigInt.java
@@ -1,0 +1,79 @@
+/*
+ *  Copyright 2001-2009 Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.time.contrib.hibernate;
+
+import java.io.File;
+import java.sql.SQLException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
+import org.joda.time.DateTime;
+
+public class TestPersistentDateTimeAsBigInt extends HibernateTestCase
+{
+    private DateTime[] writeReadTimes = new DateTime[]
+    {
+        new DateTime(0),
+		new DateTime(1000),
+		new DateTime(1000000)
+    };
+
+    public void testSimpleStore() throws SQLException
+    {
+        SessionFactory factory = getSessionFactory();
+
+        Session session = factory.openSession();
+
+        for (int i = 0; i<writeReadTimes.length; i++)
+        {
+            DateTime writeReadTime = writeReadTimes[i];
+
+            ThingWithDateTime thing = new ThingWithDateTime();
+            thing.setId(i);
+            thing.setDateTime(writeReadTime);
+
+            session.save(thing);
+        }
+
+        session.flush();
+        session.connection().commit();
+        session.close();
+
+        for (int i = 0; i<writeReadTimes.length; i++)
+        {
+            DateTime writeReadTime = writeReadTimes[i];
+
+            session = factory.openSession();
+            ThingWithDateTime thingReread = (ThingWithDateTime)session.get(ThingWithDateTime.class, new Integer(i));
+
+            assertNotNull("get failed - thing#'" + i + "'not found", thingReread);
+            assertNotNull("get failed - returned null", thingReread.getDateTime());
+
+			DateTime reReadTime = thingReread.getDateTime();
+			if (writeReadTime.getMillis() != reReadTime.getMillis())
+			{
+				fail("get failed - returned different date. expected " + writeReadTime + " was " + thingReread.getDateTime());
+			}
+		}
+
+		session.close();
+    }
+
+	protected void setupConfiguration(Configuration cfg)
+	{
+		cfg.addFile(new File("src/test/java/org/joda/time/contrib/hibernate/thingWithDateTimeAsBigInt.hbm.xml"));
+	}
+}

--- a/src/test/java/org/joda/time/contrib/hibernate/ThingWithDateTime.java
+++ b/src/test/java/org/joda/time/contrib/hibernate/ThingWithDateTime.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright 2001-2009 Stephen Colebourne
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.joda.time.contrib.hibernate;
+
+import java.io.Serializable;
+import org.joda.time.DateTime;
+
+public class ThingWithDateTime implements Serializable
+{
+	private int id;
+	private DateTime dateTime;
+
+	public ThingWithDateTime()
+	{}
+	
+	public int getId()
+	{
+		return id;
+	}
+
+	public void setId(int id)
+	{
+		this.id = id;
+	}
+
+	public DateTime getDateTime()
+	{
+		return dateTime;
+	}
+
+	public void setDateTime(DateTime dateTime)
+	{
+		this.dateTime = dateTime;
+	}
+}

--- a/src/test/java/org/joda/time/contrib/hibernate/thingWithDateTime.hbm.xml
+++ b/src/test/java/org/joda/time/contrib/hibernate/thingWithDateTime.hbm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.joda.time.contrib.hibernate">
+
+    <class name="ThingWithDateTime">
+        <id name="id"/>
+		<property  name="dateTime" type="org.joda.time.contrib.hibernate.PersistentDateTimeAsBigInt"/>
+
+    </class>
+
+
+</hibernate-mapping>

--- a/src/test/java/org/joda/time/contrib/hibernate/thingWithDateTimeAsBigInt.hbm.xml
+++ b/src/test/java/org/joda/time/contrib/hibernate/thingWithDateTimeAsBigInt.hbm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC
+        "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.joda.time.contrib.hibernate">
+
+    <class name="ThingWithDateTime">
+        <id name="id"/>
+		<property name="dateTime" type="org.joda.time.contrib.hibernate.PersistentDateTimeAsBigInt"/>
+
+    </class>
+
+
+</hibernate-mapping>


### PR DESCRIPTION
Our project has the need to have millisecond accuracy for DateTime instances, so we chose to store them in MySQL as BIGINT.  We have created a mapping class that will allow us to map between the DateTime value and the milliseconds since epoch.

I thought about calling it PersistentDateTimeExact but decided it was probably better to follow the "AsBigInt" precedence.  Please rename if you feel otherwise.
